### PR TITLE
 fix bug null point exception startDocument

### DIFF
--- a/base/src/main/java/com/calpano/graphinout/base/graphml/GraphmlWriterImpl.java
+++ b/base/src/main/java/com/calpano/graphinout/base/graphml/GraphmlWriterImpl.java
@@ -19,6 +19,7 @@ public class GraphmlWriterImpl implements GraphmlWriter {
 
     @Override
     public void startDocument(GraphmlDocument doc) throws IOException {
+        xmlWriter.startDocument();
         LinkedHashMap<String, String> attributes = new LinkedHashMap<>();
         attributes.put("xmlns", HEADER_XMLNS);
         attributes.put("xmlns:xsi", HEADER_XMLNS_XSI);


### PR DESCRIPTION
In the GraphmlWriterImpl class, the xmlWriter.startDocument() code should have been added in the startDocument method