### PR TITLE
ValidatingGraphMlWriter port validation

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/base/src/main/java/com/calpano/graphinout/base/graphml/GraphmlPort.java
+++ b/base/src/main/java/com/calpano/graphinout/base/graphml/GraphmlPort.java
@@ -40,7 +40,7 @@ public class GraphmlPort extends GraphmlElement implements XMLValue {
      * </p>
      * The name of this attribute in graph is <b>name</b>
      */
-    private String name;
+    private  String name;
 
     @Override
     public LinkedHashMap<String, String> getAttributes() {


### PR DESCRIPTION
validate that the portId has ben defined in the same document.

Validate each port defines a non-empty port id.